### PR TITLE
Icon fix 1.1

### DIFF
--- a/svgs/BRKN-file-code-outline_F004D.svg
+++ b/svgs/BRKN-file-code-outline_F004D.svg
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 25.4.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
-<path d="M0,0v24h24V0H0z M20,20c0,1.1-0.9,2-2,2H6c-1.1,0-2-0.9-2-2V4c0-1.1,0.9-2,2-2h8l6,6V20z M13,4H6v16h12V9h-5V4z M11.6,17.7
-	L10.4,19L7,15.6l3.4-3.3l1.3,1.3l-2.2,2L11.6,17.7z M13.6,12.2l3.4,3.4L13.6,19l-1.3-1.3l2.1-2.1l-2.1-2.1L13.6,12.2z"/>
-</svg>

--- a/svgs/BRKN-file-word-outline_F0060.svg
+++ b/svgs/BRKN-file-word-outline_F0060.svg
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 25.4.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
-<path d="M13,4H6v16h12V9h-5V4z M14.5,16.8l1.4-6.8h1.5l-2.1,9h-1.4l-1.8-6.8L10.2,19H8.9l-2.2-9h1.5l1.4,6.8l1.8-6.8h1.3L14.5,16.8z
-	 M0,0v24h24V0H0z M20,20c0,1.1-0.9,2-2,2H6c-1.1,0-2-0.9-2-2V4c0-1.1,0.9-2,2-2h8l6,6V20z"/>
-</svg>


### PR DESCRIPTION
This pull request is fixing an issue where two BRKN inverted icons overlap with the intended character code of two other icons that had been changed to use the correct unicodes.

- BRKN-file-code-outline_F004D overlaps with arrow-left_F004D
- BRKN-file-word-outline_F0060 overlaps with icon-arrow-up-bold-circle-outline_F0060

The BRKN Prefix files will be deleted as to not create a conflict in the font.