### PR TITLE
adding icon components

### DIFF
--- a/.github/workflows/compass-icons.yml
+++ b/.github/workflows/compass-icons.yml
@@ -30,5 +30,5 @@ jobs:
             - name: Deploy
               uses: JamesIves/github-pages-deploy-action@4.1.4
               with:
-                branch: gh-pages
-                folder: fontello
+                  branch: gh-pages
+                  folder: fontello

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,9 @@ name: build and publish
 
 # This action will trigger on every published release
 on:
-  release:
-    types:
-      - published
+    release:
+        types:
+            - published
 
 # Job will run on a ubuntu instance
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 build
+components
 dist
 config.json
 fontello*

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+build
+node_modules
+svgs
+.github
+
+*.json
+*.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,5 @@
 {
-  "tabWidth": 4,
-  "printWidth": 120,
-  "singleQuote": true
+    "tabWidth": 4,
+    "printWidth": 120,
+    "singleQuote": true
 }

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Simple steps to adding new icons to the Compass Icons font
 
 -   Append the identified hexadecimal character code to the filename after a pipe character e.g. "account-outline|F0013.svg".
 
-## Import into Github Repository 
+## Import into Github Repository
 
 #### Upload your font file to the SVG folder
 
@@ -75,12 +75,14 @@ Simple steps to adding new icons to the Compass Icons font
 -   When everything looks accurate, click on the green "Commit changes" button
 -   Add any of designers the UX Team at Mattermost as a reviewer (e.g. @andrewbrown00, @mathewbirtch, @abhijit-singh, @anneliseklein, @michaelgamble)
 -   When all the information looks accurate, click the green "Create pull request" button.
-  
+
 #### Font icon package creation
+
 -   At this point you are waiting for the approval of the pull request
 -   When the commit is approved by a member of the design team the font package will automatically be created and is ready to download for use (you will get a github notificaiton when approved)
-  
+
 #### Download font package
+
 -   Navigate to the root of the compass-icon repository
 -   https://github.com/mattermost/compass-icons/
 -   Click on the "Actions" tab

--- a/generate-data.js
+++ b/generate-data.js
@@ -4,6 +4,10 @@ const path = require('path');
 
 const fse = require('fs-extra');
 
+const fs = require('fs');
+
+const _ = require('lodash');
+
 import { getFileData, generateGlyphs, writeJSONToDisk, writeToDisk } from './utils';
 
 // generate config data used to generate the font icon
@@ -37,14 +41,87 @@ const iconGlyphs = configData.glyphs.map(({ css }) => `\t'${css}',`);
 const iconGlyphsData = `const IconGlyphs: IconGlyphTypes[] = [
 ${iconGlyphs.join('\n')}
 ];
-export type IconGlyphTypes = ${iconGlyphs
-    .map((glyph) => glyph.trim().slice(0, -1))
-    .join(' | ')};
+export type IconGlyphTypes = ${iconGlyphs.map((glyph) => glyph.trim().slice(0, -1)).join(' | ')};
 
 export default IconGlyphs;
 `;
 
+const componentTemplate = ({ name, content }) => `import React from 'react';
+
+export type P${name} = {
+    size: number;
+    color: string;
+};
+
+const ${name}Icon = (props: P${name}): JSX.Element => (
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        version="1.1"
+        width={props.size || 24}
+        height={props.size || 24}
+        fill={props.color || '#000000'}
+        viewBox="0 0 24 24"
+    >
+        ${content}
+    </svg>
+);
+
+export default ${name}Icon;
+`;
+
 writeToDisk('./IconGlyphs.ts', iconGlyphsData);
+
+const generateComponents = async () => {
+    const regex = /(?<group>(?<starttag><(?<tagname>svg)[^>]*>)(?<data>.*|\n*)(?<endtag><\/\3>))/gmsu;
+    const svgFileNames = fs.readdirSync('./svgs');
+    const filtered = svgFileNames
+        .filter((name) => !name.startsWith('BRKN-'))
+        .map((nonBroken) => {
+            const sanitized = nonBroken.split('_')[0];
+            return {
+                fileName: nonBroken,
+                original: sanitized,
+                pascalName: _.camelCase(sanitized).replace(/^(.)/, _.toUpper),
+            };
+        });
+
+    fs.mkdir('./build/components', () => {});
+
+    const promises = [];
+    for (let i = 0; i < filtered.length; i++) {
+        promises.push(readAndWriteFiles(filtered[i]));
+    }
+
+    promises.push(createComponentIndex(filtered));
+
+    return Promise.all(promises)
+};
+
+const readAndWriteFiles = (item) => new Promise((resolve, reject) => {
+    const regex = /(?<group>(?<starttag><(?<tagname>svg)[^>]*>)(?<data>.*|\n*)(?<endtag><\/\3>))/gmsu;
+    const svg = fs.readFileSync(`./svgs/${item.fileName}`, { encoding: 'utf-8' });
+    const result = regex.exec(svg);
+    if (result === null) {
+        console.log('##### filtered', item);
+        reject(item.fileName);
+    }
+    if (result) {
+        fs.writeFile(`./build/components/${item.original}.tsx`, componentTemplate({ name: item.pascalName, content: result.groups.data }), () => {});
+        resolve(item.fileName);
+    }
+})
+
+const createComponentIndex = (files) => new Promise((resolve, reject) => {
+    const indexFile = `${files.map((item) => `import ${item.pascalName} from './${item.original}';`).join('\n')}
+    
+export {
+    ${files.map((item) => `${item.pascalName},`).join('\n\t')}
+};
+`
+
+    fs.writeFile('./build/components/index.tsx', indexFile, () => {});
+})
+
 
 async function createPackageFile() {
     const packageData = await fse.readFile(path.resolve(packagePath, './package.json'), 'utf8');
@@ -72,4 +149,6 @@ async function createPackageFile() {
     console.log(`Created package.json in ${targetPath}`);
 }
 
-createPackageFile().then(() => console.log('### Finished creating the project files'));
+createPackageFile()
+    .then(() => generateComponents())
+    .then(() => console.log('### Finished creating the project files'));

--- a/generate-data.js
+++ b/generate-data.js
@@ -102,7 +102,6 @@ const readAndWriteFiles = (item) => new Promise((resolve, reject) => {
     const svg = fs.readFileSync(`./svgs/${item.fileName}`, { encoding: 'utf-8' });
     const result = regex.exec(svg);
     if (result === null) {
-        console.log('##### filtered', item);
         reject(item.fileName);
     }
     if (result) {
@@ -120,6 +119,7 @@ export {
 `
 
     fs.writeFile('./build/components/index.tsx', indexFile, () => {});
+    resolve();
 })
 
 

--- a/generate-data.js
+++ b/generate-data.js
@@ -112,10 +112,10 @@ const readAndWriteFiles = (item) => new Promise((resolve, reject) => {
 })
 
 const createComponentIndex = (files) => new Promise((resolve, reject) => {
-    const indexFile = `${files.map((item) => `import ${item.pascalName} from './${item.original}';`).join('\n')}
+    const indexFile = `${files.map((item) => `import ${item.pascalName}Icon from './${item.original}';`).join('\n')}
     
 export {
-    ${files.map((item) => `${item.pascalName},`).join('\n\t')}
+    ${files.map((item) => `${item.pascalName}Icon,`).join('\n\t')}
 };
 `
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mattermost/compass-icons",
-    "version": "0.1.14",
+    "version": "0.1.15",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@mattermost/compass-icons",
-            "version": "0.1.14",
+            "version": "0.1.15",
             "license": "MIT",
             "dependencies": {
                 "esm": "^3.2.25",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,14 @@
                 "lodash": "^4.17.21",
                 "needle": "^2.6.0",
                 "open": "^7.4.2",
+                "react": "^17.0.2",
                 "svgpath": "^2.3.1",
                 "typescript": "^4.4.4",
                 "unzip": "^0.1.11",
                 "xmldom": "^0.3.0"
             },
             "devDependencies": {
+                "@types/react": "^17.0.37",
                 "eslint-config-prettier": "^6.15.0",
                 "fs-extra": "^10.0.0",
                 "npm-run-all": "^4.1.5",
@@ -182,6 +184,29 @@
             "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
             "dev": true,
             "peer": true
+        },
+        "node_modules/@types/prop-types": {
+            "version": "15.7.4",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
+            "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
+            "dev": true
+        },
+        "node_modules/@types/react": {
+            "version": "17.0.37",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.37.tgz",
+            "integrity": "sha512-2FS1oTqBGcH/s0E+CjrCCR9+JMpsu9b69RTFO+40ua43ZqP5MmQ4iUde/dMjWR909KxZwmOQIFq6AV6NjEG5xg==",
+            "dev": true,
+            "dependencies": {
+                "@types/prop-types": "*",
+                "@types/scheduler": "*",
+                "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/@types/scheduler": {
+            "version": "0.16.2",
+            "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+            "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+            "dev": true
         },
         "node_modules/acorn": {
             "version": "7.4.1",
@@ -440,6 +465,12 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/csstype": {
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
+            "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==",
+            "dev": true
         },
         "node_modules/debug": {
             "version": "4.3.2",
@@ -1441,9 +1472,7 @@
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "dev": true,
-            "peer": true
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "node_modules/js-yaml": {
             "version": "3.14.1",
@@ -1550,6 +1579,17 @@
             "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
             "dev": true,
             "peer": true
+        },
+        "node_modules/loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dependencies": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            },
+            "bin": {
+                "loose-envify": "cli.js"
+            }
         },
         "node_modules/lru-cache": {
             "version": "6.0.0",
@@ -1841,6 +1881,14 @@
                 "which": "bin/which"
             }
         },
+        "node_modules/object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/object-inspect": {
             "version": "1.10.3",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
@@ -2065,6 +2113,18 @@
             "peer": true,
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/react": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+            "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+            "dependencies": {
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/read-pkg": {
@@ -2838,6 +2898,29 @@
             "dev": true,
             "peer": true
         },
+        "@types/prop-types": {
+            "version": "15.7.4",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
+            "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
+            "dev": true
+        },
+        "@types/react": {
+            "version": "17.0.37",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.37.tgz",
+            "integrity": "sha512-2FS1oTqBGcH/s0E+CjrCCR9+JMpsu9b69RTFO+40ua43ZqP5MmQ4iUde/dMjWR909KxZwmOQIFq6AV6NjEG5xg==",
+            "dev": true,
+            "requires": {
+                "@types/prop-types": "*",
+                "@types/scheduler": "*",
+                "csstype": "^3.0.2"
+            }
+        },
+        "@types/scheduler": {
+            "version": "0.16.2",
+            "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+            "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+            "dev": true
+        },
         "acorn": {
             "version": "7.4.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -3032,6 +3115,12 @@
                 "shebang-command": "^2.0.0",
                 "which": "^2.0.1"
             }
+        },
+        "csstype": {
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
+            "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==",
+            "dev": true
         },
         "debug": {
             "version": "4.3.2",
@@ -3782,9 +3871,7 @@
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "dev": true,
-            "peer": true
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "js-yaml": {
             "version": "3.14.1",
@@ -3880,6 +3967,14 @@
             "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
             "dev": true,
             "peer": true
+        },
+        "loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            }
         },
         "lru-cache": {
             "version": "6.0.0",
@@ -4111,6 +4206,11 @@
                 }
             }
         },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
         "object-inspect": {
             "version": "1.10.3",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
@@ -4273,6 +4373,15 @@
             "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
             "dev": true,
             "peer": true
+        },
+        "react": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+            "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+            "requires": {
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1"
+            }
         },
         "read-pkg": {
             "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "scripts": {
         "start": "npm run build",
         "clean": "rm -rf config.json build .fontello-session fontello* node_modules",
-        "build": "run-s build:data build:typescript build:font",
+        "build": "run-s build:data build:prettify build:typescript build:font",
         "build:data": "node -r esm generate-data.js",
+        "build:prettify": "npx prettier --write .",
         "build:font": "fontello-cli --css ./build/css --font ./build/font install",
         "build:typescript": "tsc",
         "open": "run-s build:data open:font",
@@ -36,9 +37,11 @@
         "xmldom": "^0.3.0"
     },
     "devDependencies": {
+        "@types/react": "^17.0.37",
         "eslint-config-prettier": "^6.15.0",
         "fs-extra": "^10.0.0",
         "npm-run-all": "^4.1.5",
-        "prettier": "^2.2.1"
+        "prettier": "^2.2.1",
+        "react": "^17.0.2"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mattermost/compass-icons",
-    "version": "0.1.14",
+    "version": "0.1.15",
     "private": true,
     "description": "",
     "main": "build/css/compass-icons.css",

--- a/svgs/arrow-back-ios_E811.svg
+++ b/svgs/arrow-back-ios_E811.svg
@@ -2,13 +2,6 @@
 <!-- Generator: Adobe Illustrator 24.1.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
-<style type="text/css">
-	.st0{display:none;}
-	.st1{display:inline;}
-</style>
-<g id="hold" class="st0">
-	<path class="st1" d="M18.5,3.9l-1.8-1.8L6.8,12l9.9,9.9l1.8-1.8L10.4,12L18.5,3.9z"/>
-</g>
 <g id="edit">
 	<path d="M18,3.8L16.2,2L6,12l10.2,10l1.8-1.8L9.6,12L18,3.8z"/>
 </g>

--- a/svgs/brand-gitlab_F0BA0.svg
+++ b/svgs/brand-gitlab_F0BA0.svg
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24"><path class="st0" d="M21.941,13.57l-1.065-3.28c0,0.001,0.001,0.003,0.001,0.004c-0.001-0.002-0.001-0.003-0.001-0.005c0,0,0,0,0,0
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24"><path d="M21.941,13.57l-1.065-3.28c0,0.001,0.001,0.003,0.001,0.004c-0.001-0.002-0.001-0.003-0.001-0.005c0,0,0,0,0,0
 	c0,0,0,0,0,0L18.762,3.78c-0.116-0.343-0.434-0.573-0.799-0.57c-0.366,0.002-0.675,0.228-0.789,0.575l-2.007,6.178H8.836
 	l-2.01-6.178C6.712,3.438,6.403,3.212,6.037,3.21c-0.001,0-0.003,0-0.004,0c-0.36,0-0.679,0.229-0.796,0.575l-2.108,6.503l0,0.001
 	c0,0,0,0,0,0c-0.001,0.002-0.001,0.003-0.001,0.005c0-0.001,0.001-0.003,0.001-0.004l-1.069,3.28

--- a/svgs/product-boards_0xe82e.svg
+++ b/svgs/product-boards_0xe82e.svg
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24"><path class="st0" d="M16.736,3.191C15.327,2.431,13.714,2,12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10c5.523,0,10-4.477,10-10
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24"><path d="M16.736,3.191C15.327,2.431,13.714,2,12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10c5.523,0,10-4.477,10-10
 	c0-1.708-0.428-3.316-1.183-4.722c-0.435,0.14-0.945,0.258-1.522,0.357C20.06,8.911,20.5,10.404,20.5,12c0,4.694-3.806,8.5-8.5,8.5
 	c-4.694,0-8.5-3.806-8.5-8.5c0-4.694,3.806-8.5,8.5-8.5c1.6,0,3.096,0.442,4.374,1.21C16.476,4.134,16.595,3.624,16.736,3.191z
 	 M16.084,6.943L16.084,6.943l-1.149,1.009c0,0,0,0,0,0L16.084,6.943z M15.233,6.36C14.281,5.813,13.177,5.5,12,5.5

--- a/svgs/product-playbooks_0xe82d.svg
+++ b/svgs/product-playbooks_0xe82d.svg
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24"><path class="st0" d="M8,3.5H6c-1.105,0-2,0.895-2,2V19c0,1.105,0.895,2,2,2h12c1.105,0,2-0.895,2-2V5.5c0-1.105-0.895-2-2-2h-2V5
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24"><path d="M8,3.5H6c-1.105,0-2,0.895-2,2V19c0,1.105,0.895,2,2,2h12c1.105,0,2-0.895,2-2V5.5c0-1.105-0.895-2-2-2h-2V5
 	h1.5c0.552,0,1,0.448,1,1v12.5c0,0.552-0.448,1-1,1h-11c-0.552,0-1-0.448-1-1V6c0-0.552,0.448-1,1-1H8V3.5z M11,2
 	c-0.276,0-0.5,0.224-0.5,0.5V3H9v2.5h6V3h-1.5V2.5C13.5,2.224,13.276,2,13,2H11z M10.5,16H17v1h-6.5V16z M7.5,15.75H9v1.5H7.5V15.75
 	z M10.5,12H17v1h-6.5V12z M7.5,11.75H9v1.5H7.5V11.75z M10.5,8H17v1h-6.5V8z M7.409,9.091l-0.5-0.5l0.5-0.5l0.5,0.5L9,7.5L9.5,8

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,22 +1,22 @@
 {
-  "compilerOptions": {
-    "target": "es6",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "module": "CommonJS",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "react",
-    "noEmit": false,
-    "emitDeclarationOnly": false,
-    "declaration": true,
-    "outDir": "./build"
-  },
-  "include": ["IconGlyphs.ts"],
+    "compilerOptions": {
+        "target": "es6",
+        "lib": ["dom", "dom.iterable", "esnext"],
+        "allowJs": true,
+        "skipLibCheck": true,
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "strict": true,
+        "forceConsistentCasingInFileNames": true,
+        "module": "CommonJS",
+        "moduleResolution": "node",
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "jsx": "react",
+        "noEmit": false,
+        "emitDeclarationOnly": false,
+        "declaration": true,
+        "outDir": "./build"
+    },
+    "include": ["IconGlyphs.ts", "./components/*"]
 }


### PR DESCRIPTION
this PR adds icon components in a new `@mattermost/compass-icons/components` folder.

These can then be imported and used just as regular react components. 
This eliminates some pain-points when using fonts and CSS (like line-height adjustments, correct aligning, etc.)

components can now be imported and used like this:

```typescript jsx
import FileImageOutlineIcon from '@mattermost/compass-icons/components';

...

const Component = () => {

    ...
    
    return (
        <div>
            <FileImageOutlineIcon size={20} color={'#EEE'} />
        </div>
    );
}
```