### PR TITLE
Bump version to 0.1.22 fixes bell alignment and includes gif icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@mattermost/compass-icons",
-    "version": "0.1.21",
+    "version": "0.1.22",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mattermost/compass-icons",
-    "version": "0.1.21",
+    "version": "0.1.22",
     "private": true,
     "description": "",
     "main": "build/css/compass-icons.css",


### PR DESCRIPTION
To update and publish to npm

should be merged after #39 