### PR TITLE
bump version to 0.1.26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mattermost/compass-icons",
-    "version": "0.1.24",
+    "version": "0.1.26",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@mattermost/compass-icons",
-            "version": "0.1.24",
+            "version": "0.1.26",
             "license": "MIT",
             "dependencies": {
                 "esm": "3.2.25",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mattermost/compass-icons",
-    "version": "0.1.25",
+    "version": "0.1.26",
     "private": true,
     "description": "",
     "main": "build/css/compass-icons.css",


### PR DESCRIPTION
# Bump version to 0.1.26

Bump version to include last icons https://github.com/mattermost/compass-icons/pull/47
