### PR TITLE
Move dependencies to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,25 +8,23 @@
             "name": "@mattermost/compass-icons",
             "version": "0.1.28",
             "license": "MIT",
-            "dependencies": {
-                "esm": "3.2.25",
-                "fontello-batch-cli": "4.0.0",
-                "fontello-cli": "0.6.2",
-                "lodash": "4.17.21",
-                "needle": "3.0.0",
-                "open": "8.4.0",
-                "svgpath": "2.5.0",
-                "unzip": "0.1.11",
-                "xmldom": "0.6.0"
-            },
             "devDependencies": {
                 "@types/react": "17.0.39",
                 "eslint-config-prettier": "8.4.0",
+                "esm": "3.2.25",
+                "fontello-batch-cli": "4.0.0",
+                "fontello-cli": "0.6.2",
                 "fs-extra": "10.0.1",
+                "lodash": "4.17.21",
+                "needle": "3.0.0",
                 "npm-run-all": "4.1.5",
+                "open": "8.4.0",
                 "prettier": "2.5.1",
                 "react": "17.0.2",
-                "typescript": "4.6.2"
+                "svgpath": "2.5.0",
+                "typescript": "4.6.2",
+                "unzip": "0.1.11",
+                "xmldom": "0.6.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -288,6 +286,7 @@
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
             "dependencies": {
                 "sprintf-js": "~1.0.2"
             }
@@ -305,12 +304,14 @@
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true
         },
         "node_modules/big-integer": {
             "version": "1.6.48",
             "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
             "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+            "dev": true,
             "engines": {
                 "node": ">=0.6"
             }
@@ -319,6 +320,7 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
             "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+            "dev": true,
             "dependencies": {
                 "buffers": "~0.1.1",
                 "chainsaw": "~0.1.0"
@@ -330,12 +332,14 @@
         "node_modules/bluebird": {
             "version": "3.4.7",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-            "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
+            "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
+            "dev": true
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -345,6 +349,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
             "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10"
             }
@@ -353,6 +358,7 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
             "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
+            "dev": true,
             "engines": {
                 "node": ">=0.2.0"
             }
@@ -384,6 +390,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
             "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+            "dev": true,
             "dependencies": {
                 "traverse": ">=0.3.0 <0.4"
             },
@@ -432,6 +439,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
             "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+            "dev": true,
             "engines": {
                 "node": ">=0.1.90"
             }
@@ -439,17 +447,20 @@
         "node_modules/commander": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
+            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
+            "dev": true
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
         },
         "node_modules/core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
         },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
@@ -501,6 +512,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
             "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -534,6 +546,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
             "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+            "dev": true,
             "dependencies": {
                 "readable-stream": "^2.0.2"
             }
@@ -541,12 +554,14 @@
         "node_modules/duplexer2/node_modules/isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
         },
         "node_modules/duplexer2/node_modules/readable-stream": {
             "version": "2.3.7",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
             "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dev": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -561,6 +576,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
@@ -778,6 +794,7 @@
             "version": "3.2.25",
             "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
             "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -946,6 +963,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/fontello-batch-cli/-/fontello-batch-cli-4.0.0.tgz",
             "integrity": "sha512-8LHFhHFNKpEkvT06YtiKPVJyUH+/I+qlOtXUgD1J/f+nXrjZNWUb0I9P13Nv81X64e8eXV43DuOfU8UXXNoiBQ==",
+            "dev": true,
             "dependencies": {
                 "argparse": "^1.0.10",
                 "lodash": "^4.17.15",
@@ -963,6 +981,7 @@
             "version": "3.2.7",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
             "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+            "dev": true,
             "dependencies": {
                 "ms": "^2.1.1"
             }
@@ -971,6 +990,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
             "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -979,6 +999,7 @@
             "version": "2.9.1",
             "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
             "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
+            "dev": true,
             "dependencies": {
                 "debug": "^3.2.6",
                 "iconv-lite": "^0.4.4",
@@ -995,6 +1016,7 @@
             "version": "6.4.0",
             "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
             "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
+            "dev": true,
             "dependencies": {
                 "is-wsl": "^1.1.0"
             },
@@ -1007,6 +1029,7 @@
             "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
             "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
             "deprecated": "Deprecated due to CVE-2021-21366 resolved in 0.5.0",
+            "dev": true,
             "engines": {
                 "node": ">=0.1"
             }
@@ -1015,6 +1038,7 @@
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/fontello-cli/-/fontello-cli-0.6.2.tgz",
             "integrity": "sha512-/85DkJNgbGOu0sh7sUAxWLbzq0cytWQtvn7WuRzpn6mcla6TEQz1JbYmpkAjX/PJiW867ujgoaFqm4CUoBBgwA==",
+            "dev": true,
             "dependencies": {
                 "colors": "^1.4.0",
                 "commander": "^3.0.0",
@@ -1034,6 +1058,7 @@
             "version": "3.2.7",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
             "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+            "dev": true,
             "dependencies": {
                 "ms": "^2.1.1"
             }
@@ -1042,6 +1067,7 @@
             "version": "2.9.1",
             "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
             "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
+            "dev": true,
             "dependencies": {
                 "debug": "^3.2.6",
                 "iconv-lite": "^0.4.4",
@@ -1058,6 +1084,7 @@
             "version": "7.4.2",
             "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
             "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+            "dev": true,
             "dependencies": {
                 "is-docker": "^2.0.0",
                 "is-wsl": "^2.1.1"
@@ -1086,7 +1113,8 @@
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
         },
         "node_modules/function-bind": {
             "version": "1.1.1",
@@ -1119,6 +1147,7 @@
             "version": "7.1.7",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
             "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+            "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -1166,7 +1195,8 @@
         "node_modules/graceful-fs": {
             "version": "4.2.6",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-            "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+            "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+            "dev": true
         },
         "node_modules/has": {
             "version": "1.0.3",
@@ -1221,6 +1251,7 @@
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3"
             },
@@ -1269,6 +1300,7 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -1277,7 +1309,8 @@
         "node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
         },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
@@ -1349,6 +1382,7 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
             "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "dev": true,
             "bin": {
                 "is-docker": "cli.js"
             },
@@ -1463,6 +1497,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
             "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "dev": true,
             "dependencies": {
                 "is-docker": "^2.0.0"
             },
@@ -1473,7 +1508,8 @@
         "node_modules/isarray": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+            "dev": true
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -1550,7 +1586,8 @@
         "node_modules/listenercount": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-            "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc="
+            "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
+            "dev": true
         },
         "node_modules/load-json-file": {
             "version": "4.0.0",
@@ -1570,7 +1607,8 @@
         "node_modules/lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true
         },
         "node_modules/lodash.clonedeep": {
             "version": "4.5.0",
@@ -1622,6 +1660,7 @@
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
             "integrity": "sha1-mesFAJOzTf+t5CG5rAtBCpz6F88=",
+            "dev": true,
             "dependencies": {
                 "buffers": "~0.1.1",
                 "readable-stream": "~1.0.0"
@@ -1637,9 +1676,10 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -1648,14 +1688,19 @@
             }
         },
         "node_modules/minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+            "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/mkdirp": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
             "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "dev": true,
             "bin": {
                 "mkdirp": "bin/cmd.js"
             },
@@ -1666,7 +1711,8 @@
         "node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
@@ -1679,6 +1725,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/needle/-/needle-3.0.0.tgz",
             "integrity": "sha512-eGr0qnfHxAjr+Eptl1zr2lgUQUPC1SZfTkg2kFi0kxr1ChJonHUVYobkug8siBKMlyUVVp56MSkp6CSeXH/jgw==",
+            "dev": true,
             "dependencies": {
                 "debug": "^3.2.6",
                 "iconv-lite": "^0.4.4",
@@ -1695,6 +1742,7 @@
             "version": "3.2.7",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
             "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+            "dev": true,
             "dependencies": {
                 "ms": "^2.1.1"
             }
@@ -1938,6 +1986,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -1946,6 +1995,7 @@
             "version": "8.4.0",
             "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
             "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+            "dev": true,
             "dependencies": {
                 "define-lazy-prop": "^2.0.0",
                 "is-docker": "^2.1.1",
@@ -1980,6 +2030,7 @@
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/over/-/over-0.0.5.tgz",
             "integrity": "sha1-8phS5w/X4l82DgE6jsRMgq7bVwg=",
+            "dev": true,
             "engines": {
                 "node": "*"
             }
@@ -2014,6 +2065,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2092,7 +2144,8 @@
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true
         },
         "node_modules/progress": {
             "version": "2.0.3",
@@ -2108,6 +2161,7 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/pullstream/-/pullstream-0.4.1.tgz",
             "integrity": "sha1-1vs79a7Wl+gxFQ6xACwlo/iuExQ=",
+            "dev": true,
             "dependencies": {
                 "over": ">= 0.0.5 < 1",
                 "readable-stream": "~1.0.31",
@@ -2156,6 +2210,7 @@
             "version": "1.0.34",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
             "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+            "dev": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.1",
@@ -2228,17 +2283,20 @@
         "node_modules/safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
         },
         "node_modules/sax": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+            "dev": true
         },
         "node_modules/semver": {
             "version": "7.3.5",
@@ -2259,7 +2317,8 @@
         "node_modules/setimmediate": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-            "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+            "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+            "dev": true
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
@@ -2285,10 +2344,13 @@
             }
         },
         "node_modules/shell-quote": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-            "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
-            "dev": true
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
+            "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/slice-ansi": {
             "version": "4.0.0",
@@ -2312,6 +2374,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/slice-stream/-/slice-stream-1.0.0.tgz",
             "integrity": "sha1-WzO9ZvATsaf4ZGCwPUY97DmtPqA=",
+            "dev": true,
             "dependencies": {
                 "readable-stream": "~1.0.31"
             }
@@ -2351,12 +2414,14 @@
         "node_modules/sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
         },
         "node_modules/string_decoder": {
             "version": "0.10.31",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+            "dev": true
         },
         "node_modules/string-width": {
             "version": "4.2.2",
@@ -2467,7 +2532,8 @@
         "node_modules/svgpath": {
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/svgpath/-/svgpath-2.5.0.tgz",
-            "integrity": "sha512-o/vohwqjUO9nDAh4rcjE3KaW/v//At8UJu2LJMybXidf5QLQLVA4bxH0//4YCsr+1H4Gw1Wi/Jc62ynzSBYidw=="
+            "integrity": "sha512-o/vohwqjUO9nDAh4rcjE3KaW/v//At8UJu2LJMybXidf5QLQLVA4bxH0//4YCsr+1H4Gw1Wi/Jc62ynzSBYidw==",
+            "dev": true
         },
         "node_modules/table": {
             "version": "6.7.1",
@@ -2522,6 +2588,7 @@
             "version": "0.3.9",
             "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
             "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+            "dev": true,
             "engines": {
                 "node": "*"
             }
@@ -2593,6 +2660,7 @@
             "version": "0.1.11",
             "resolved": "https://registry.npmjs.org/unzip/-/unzip-0.1.11.tgz",
             "integrity": "sha1-iXScY7BY19kNYZ+GuYqhU107l/A=",
+            "dev": true,
             "dependencies": {
                 "binary": ">= 0.3.0 < 1",
                 "match-stream": ">= 0.0.2 < 1",
@@ -2605,6 +2673,7 @@
             "version": "0.10.11",
             "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
             "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+            "dev": true,
             "dependencies": {
                 "big-integer": "^1.6.17",
                 "binary": "~0.3.0",
@@ -2622,6 +2691,7 @@
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
             "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+            "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.1.2",
                 "inherits": "~2.0.0",
@@ -2635,12 +2705,14 @@
         "node_modules/unzipper/node_modules/isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
         },
         "node_modules/unzipper/node_modules/mkdirp": {
             "version": "0.5.5",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
             "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+            "dev": true,
             "dependencies": {
                 "minimist": "^1.2.5"
             },
@@ -2652,6 +2724,7 @@
             "version": "2.3.7",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
             "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dev": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -2666,6 +2739,7 @@
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
             "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+            "dev": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -2677,6 +2751,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
@@ -2694,7 +2769,8 @@
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
         },
         "node_modules/v8-compile-cache": {
             "version": "2.3.0",
@@ -2758,12 +2834,14 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
         },
         "node_modules/xmldom": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
             "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
+            "dev": true,
             "engines": {
                 "node": ">=10.0.0"
             }
@@ -2987,6 +3065,7 @@
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
             "requires": {
                 "sprintf-js": "~1.0.2"
             }
@@ -3001,17 +3080,20 @@
         "balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true
         },
         "big-integer": {
             "version": "1.6.48",
             "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-            "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
+            "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+            "dev": true
         },
         "binary": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
             "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+            "dev": true,
             "requires": {
                 "buffers": "~0.1.1",
                 "chainsaw": "~0.1.0"
@@ -3020,12 +3102,14 @@
         "bluebird": {
             "version": "3.4.7",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-            "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
+            "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
+            "dev": true
         },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3034,12 +3118,14 @@
         "buffer-indexof-polyfill": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A=="
+            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+            "dev": true
         },
         "buffers": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-            "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
+            "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
+            "dev": true
         },
         "call-bind": {
             "version": "1.0.2",
@@ -3062,6 +3148,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
             "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+            "dev": true,
             "requires": {
                 "traverse": ">=0.3.0 <0.4"
             }
@@ -3097,22 +3184,26 @@
         "colors": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-            "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+            "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+            "dev": true
         },
         "commander": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
+            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
+            "dev": true
         },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
         },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
         },
         "cross-spawn": {
             "version": "7.0.3",
@@ -3152,7 +3243,8 @@
         "define-lazy-prop": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
+            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+            "dev": true
         },
         "define-properties": {
             "version": "1.1.3",
@@ -3177,6 +3269,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
             "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+            "dev": true,
             "requires": {
                 "readable-stream": "^2.0.2"
             },
@@ -3184,12 +3277,14 @@
                 "isarray": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
                 },
                 "readable-stream": {
                     "version": "2.3.7",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
                     "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -3204,6 +3299,7 @@
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
                     }
@@ -3374,7 +3470,8 @@
         "esm": {
             "version": "3.2.25",
             "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-            "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+            "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+            "dev": true
         },
         "espree": {
             "version": "7.3.1",
@@ -3509,6 +3606,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/fontello-batch-cli/-/fontello-batch-cli-4.0.0.tgz",
             "integrity": "sha512-8LHFhHFNKpEkvT06YtiKPVJyUH+/I+qlOtXUgD1J/f+nXrjZNWUb0I9P13Nv81X64e8eXV43DuOfU8UXXNoiBQ==",
+            "dev": true,
             "requires": {
                 "argparse": "^1.0.10",
                 "lodash": "^4.17.15",
@@ -3523,6 +3621,7 @@
                     "version": "3.2.7",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
                     "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+                    "dev": true,
                     "requires": {
                         "ms": "^2.1.1"
                     }
@@ -3530,12 +3629,14 @@
                 "is-wsl": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-                    "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+                    "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+                    "dev": true
                 },
                 "needle": {
                     "version": "2.9.1",
                     "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
                     "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
+                    "dev": true,
                     "requires": {
                         "debug": "^3.2.6",
                         "iconv-lite": "^0.4.4",
@@ -3546,6 +3647,7 @@
                     "version": "6.4.0",
                     "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
                     "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
+                    "dev": true,
                     "requires": {
                         "is-wsl": "^1.1.0"
                     }
@@ -3553,7 +3655,8 @@
                 "xmldom": {
                     "version": "0.1.31",
                     "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-                    "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ=="
+                    "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
+                    "dev": true
                 }
             }
         },
@@ -3561,6 +3664,7 @@
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/fontello-cli/-/fontello-cli-0.6.2.tgz",
             "integrity": "sha512-/85DkJNgbGOu0sh7sUAxWLbzq0cytWQtvn7WuRzpn6mcla6TEQz1JbYmpkAjX/PJiW867ujgoaFqm4CUoBBgwA==",
+            "dev": true,
             "requires": {
                 "colors": "^1.4.0",
                 "commander": "^3.0.0",
@@ -3574,6 +3678,7 @@
                     "version": "3.2.7",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
                     "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+                    "dev": true,
                     "requires": {
                         "ms": "^2.1.1"
                     }
@@ -3582,6 +3687,7 @@
                     "version": "2.9.1",
                     "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
                     "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
+                    "dev": true,
                     "requires": {
                         "debug": "^3.2.6",
                         "iconv-lite": "^0.4.4",
@@ -3592,6 +3698,7 @@
                     "version": "7.4.2",
                     "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
                     "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+                    "dev": true,
                     "requires": {
                         "is-docker": "^2.0.0",
                         "is-wsl": "^2.1.1"
@@ -3613,7 +3720,8 @@
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
         },
         "function-bind": {
             "version": "1.1.1",
@@ -3643,6 +3751,7 @@
             "version": "7.1.7",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
             "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+            "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -3675,7 +3784,8 @@
         "graceful-fs": {
             "version": "4.2.6",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-            "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+            "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+            "dev": true
         },
         "has": {
             "version": "1.0.3",
@@ -3715,6 +3825,7 @@
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
             }
@@ -3748,6 +3859,7 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -3756,7 +3868,8 @@
         "inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
         },
         "is-arrayish": {
             "version": "0.2.1",
@@ -3803,7 +3916,8 @@
         "is-docker": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "dev": true
         },
         "is-extglob": {
             "version": "2.1.1",
@@ -3870,6 +3984,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
             "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "dev": true,
             "requires": {
                 "is-docker": "^2.0.0"
             }
@@ -3877,7 +3992,8 @@
         "isarray": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+            "dev": true
         },
         "isexe": {
             "version": "2.0.0",
@@ -3946,7 +4062,8 @@
         "listenercount": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-            "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc="
+            "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
+            "dev": true
         },
         "load-json-file": {
             "version": "4.0.0",
@@ -3963,7 +4080,8 @@
         "lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true
         },
         "lodash.clonedeep": {
             "version": "4.5.0",
@@ -4009,6 +4127,7 @@
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
             "integrity": "sha1-mesFAJOzTf+t5CG5rAtBCpz6F88=",
+            "dev": true,
             "requires": {
                 "buffers": "~0.1.1",
                 "readable-stream": "~1.0.0"
@@ -4021,27 +4140,31 @@
             "dev": true
         },
         "minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+            "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+            "dev": true
         },
         "mkdirp": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "dev": true
         },
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
         },
         "natural-compare": {
             "version": "1.4.0",
@@ -4054,6 +4177,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/needle/-/needle-3.0.0.tgz",
             "integrity": "sha512-eGr0qnfHxAjr+Eptl1zr2lgUQUPC1SZfTkg2kFi0kxr1ChJonHUVYobkug8siBKMlyUVVp56MSkp6CSeXH/jgw==",
+            "dev": true,
             "requires": {
                 "debug": "^3.2.6",
                 "iconv-lite": "^0.4.4",
@@ -4064,6 +4188,7 @@
                     "version": "3.2.7",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
                     "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+                    "dev": true,
                     "requires": {
                         "ms": "^2.1.1"
                     }
@@ -4254,6 +4379,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -4262,6 +4388,7 @@
             "version": "8.4.0",
             "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
             "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+            "dev": true,
             "requires": {
                 "define-lazy-prop": "^2.0.0",
                 "is-docker": "^2.1.1",
@@ -4286,7 +4413,8 @@
         "over": {
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/over/-/over-0.0.5.tgz",
-            "integrity": "sha1-8phS5w/X4l82DgE6jsRMgq7bVwg="
+            "integrity": "sha1-8phS5w/X4l82DgE6jsRMgq7bVwg=",
+            "dev": true
         },
         "parent-module": {
             "version": "1.0.1",
@@ -4311,7 +4439,8 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
         },
         "path-key": {
             "version": "3.1.1",
@@ -4363,7 +4492,8 @@
         "process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true
         },
         "progress": {
             "version": "2.0.3",
@@ -4376,6 +4506,7 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/pullstream/-/pullstream-0.4.1.tgz",
             "integrity": "sha1-1vs79a7Wl+gxFQ6xACwlo/iuExQ=",
+            "dev": true,
             "requires": {
                 "over": ">= 0.0.5 < 1",
                 "readable-stream": "~1.0.31",
@@ -4415,6 +4546,7 @@
             "version": "1.0.34",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
             "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+            "dev": true,
             "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.1",
@@ -4466,17 +4598,20 @@
         "safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
         },
         "safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
         },
         "sax": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+            "dev": true
         },
         "semver": {
             "version": "7.3.5",
@@ -4491,7 +4626,8 @@
         "setimmediate": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-            "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+            "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+            "dev": true
         },
         "shebang-command": {
             "version": "2.0.0",
@@ -4511,9 +4647,9 @@
             "peer": true
         },
         "shell-quote": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-            "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
+            "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==",
             "dev": true
         },
         "slice-ansi": {
@@ -4532,6 +4668,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/slice-stream/-/slice-stream-1.0.0.tgz",
             "integrity": "sha1-WzO9ZvATsaf4ZGCwPUY97DmtPqA=",
+            "dev": true,
             "requires": {
                 "readable-stream": "~1.0.31"
             }
@@ -4571,12 +4708,14 @@
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
         },
         "string_decoder": {
             "version": "0.10.31",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+            "dev": true
         },
         "string-width": {
             "version": "4.2.2",
@@ -4657,7 +4796,8 @@
         "svgpath": {
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/svgpath/-/svgpath-2.5.0.tgz",
-            "integrity": "sha512-o/vohwqjUO9nDAh4rcjE3KaW/v//At8UJu2LJMybXidf5QLQLVA4bxH0//4YCsr+1H4Gw1Wi/Jc62ynzSBYidw=="
+            "integrity": "sha512-o/vohwqjUO9nDAh4rcjE3KaW/v//At8UJu2LJMybXidf5QLQLVA4bxH0//4YCsr+1H4Gw1Wi/Jc62ynzSBYidw==",
+            "dev": true
         },
         "table": {
             "version": "6.7.1",
@@ -4706,7 +4846,8 @@
         "traverse": {
             "version": "0.3.9",
             "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-            "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
+            "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+            "dev": true
         },
         "type-check": {
             "version": "0.4.0",
@@ -4753,6 +4894,7 @@
             "version": "0.1.11",
             "resolved": "https://registry.npmjs.org/unzip/-/unzip-0.1.11.tgz",
             "integrity": "sha1-iXScY7BY19kNYZ+GuYqhU107l/A=",
+            "dev": true,
             "requires": {
                 "binary": ">= 0.3.0 < 1",
                 "match-stream": ">= 0.0.2 < 1",
@@ -4765,6 +4907,7 @@
             "version": "0.10.11",
             "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
             "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+            "dev": true,
             "requires": {
                 "big-integer": "^1.6.17",
                 "binary": "~0.3.0",
@@ -4782,6 +4925,7 @@
                     "version": "1.0.12",
                     "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
                     "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+                    "dev": true,
                     "requires": {
                         "graceful-fs": "^4.1.2",
                         "inherits": "~2.0.0",
@@ -4792,12 +4936,14 @@
                 "isarray": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
                 },
                 "mkdirp": {
                     "version": "0.5.5",
                     "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
                     "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+                    "dev": true,
                     "requires": {
                         "minimist": "^1.2.5"
                     }
@@ -4806,6 +4952,7 @@
                     "version": "2.3.7",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
                     "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -4820,6 +4967,7 @@
                     "version": "2.7.1",
                     "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
                     "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+                    "dev": true,
                     "requires": {
                         "glob": "^7.1.3"
                     }
@@ -4828,6 +4976,7 @@
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
                     }
@@ -4847,7 +4996,8 @@
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
         },
         "v8-compile-cache": {
             "version": "2.3.0",
@@ -4899,12 +5049,14 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
         },
         "xmldom": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-            "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
+            "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
+            "dev": true
         },
         "yallist": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -24,24 +24,22 @@
     ],
     "author": "Mattermost",
     "license": "MIT",
-    "dependencies": {
-        "esm": "3.2.25",
-        "fontello-batch-cli": "4.0.0",
-        "fontello-cli": "0.6.2",
-        "lodash": "4.17.21",
-        "needle": "3.0.0",
-        "open": "8.4.0",
-        "svgpath": "2.5.0",
-        "unzip": "0.1.11",
-        "xmldom": "0.6.0"
-    },
     "devDependencies": {
         "@types/react": "17.0.39",
         "eslint-config-prettier": "8.4.0",
+        "esm": "3.2.25",
+        "fontello-batch-cli": "4.0.0",
+        "fontello-cli": "0.6.2",
         "fs-extra": "10.0.1",
+        "lodash": "4.17.21",
+        "needle": "3.0.0",
         "npm-run-all": "4.1.5",
+        "open": "8.4.0",
         "prettier": "2.5.1",
         "react": "17.0.2",
-        "typescript": "4.6.2"
+        "svgpath": "2.5.0",
+        "typescript": "4.6.2",
+        "unzip": "0.1.11",
+        "xmldom": "0.6.0"
     }
 }


### PR DESCRIPTION
This PR moves the dependencies to devDependencies because:
1. all dependencies are only used to build the project
2. no dependencies are needed when the package is installed
3. `fontello-batch-cli` is no longer maintained (apparently) and has a critical vulnerability thus npm audit yells about it and there is no fix

By moving all dependencies as devDependencies, the project still builds and projects using this library won't complain about the vulnerability.

Once merged we should publish a new version.
