### PR TITLE
Feature/improve icon sizing

### DIFF
--- a/generate-data.js
+++ b/generate-data.js
@@ -63,8 +63,8 @@ const ${name}Icon: React.FC<IconProps> = ({ size, color, ...rest}: IconProps): J
     <svg
         xmlns="http://www.w3.org/2000/svg"
         version="1.1"
-        width={size || 24}
-        height={size || 24}
+        width={size || '1em'}
+        height={size || '1em'}
         fill={color || 'currentColor'}
         viewBox="0 0 24 24"
         {...rest}
@@ -142,7 +142,7 @@ const createComponentIndex = (files) =>
 
 const createComponentProps = () =>
     new Promise((resolve) => {
-        const indexFileData = `type IconProps = {\n\tsize?:number;\n\tcolor?:string;\n\ttitle?:string;\n};\n\nexport default IconProps;`;
+        const indexFileData = `type IconProps = {\n\tsize?:number|string;\n\tcolor?:string;\n\ttitle?:string;\n};\n\nexport default IconProps;`;
 
         fs.writeFile(path.join(componentPath, 'props.ts'), indexFileData, () => {});
         resolve();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mattermost/compass-icons",
-    "version": "0.1.34",
+    "version": "0.1.35",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@mattermost/compass-icons",
-            "version": "0.1.34",
+            "version": "0.1.35",
             "license": "MIT",
             "devDependencies": {
                 "@types/react": "17.0.39",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mattermost/compass-icons",
-    "version": "0.1.34",
+    "version": "0.1.35",
     "private": true,
     "description": "",
     "main": "build/css/compass-icons.css",


### PR DESCRIPTION
improves icon sizing when the icon should have the same size as the text (if present). The default value now uses `1em` as the default value and strings (to allow for `%`, `vh`, `vw`, `rem` or `em` values) in the size prop.
