### PR TITLE
Update compass-icons.yml

### DIFF
--- a/.github/workflows/compass-icons.yml
+++ b/.github/workflows/compass-icons.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
             - name: npm install and package
               run: |
                   npm install
@@ -23,12 +23,12 @@ jobs:
                   mv fontello/demo.html fontello/index.html
                   cp ./build/IconGlyphs* ./fontello
             - name: Archive artifacts
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               with:
                   name: CompassIconFont
                   path: fontello
             - name: Deploy
-              uses: JamesIves/github-pages-deploy-action@4.1.4
+              uses: JamesIves/github-pages-deploy-action@4.4.1
               with:
                   branch: gh-pages
                   folder: fontello


### PR DESCRIPTION
Updated the workflow yml to use newer versions to comply with Github actions changes: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/