### PR TITLE
Download Fontello package manually instead of using fontello-cli

### DIFF
--- a/.github/workflows/compass-icons.yml
+++ b/.github/workflows/compass-icons.yml
@@ -12,11 +12,15 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v3
-            - name: npm install and package
+            - name: npm install and build
               run: |
                   npm install
                   npm run build
-                  npm run package
+            - name: Download demo package from Fontello
+              run: |
+                curl https://fontello.com/`cat .fontello-session`/get > fontello.zip
+                7z x fontello.zip
+                rm fontello.zip
             - name: Rename downloaded fontello package
               run: |
                   mv fontello* fontello

--- a/package.json
+++ b/package.json
@@ -13,9 +13,7 @@
         "build:font": "fontello-cli --css ./build/css --font ./build/font install",
         "build:typescript": "tsc",
         "open": "run-s build:data open:font",
-        "open:font": "fontello-cli open",
-        "package": "run-s build:data package:font",
-        "package:font": "fontello-cli install"
+        "open:font": "fontello-cli open"
     },
     "keywords": [
         "mattermost",


### PR DESCRIPTION
For whatever reason, it seems like the `unzipper` package used by `fontello-cli` has started misplacing a chunk of some files when extracting the package of files downloaded from Fontello. Since both `unzipper` and `fontello-cli` are old and without a ton of support, we can just hit the API directly to get the files and extract them ourselves.

Additional context: https://community.mattermost.com/core/pl/56tmfg73i7gtjyrij3rsesou3r