### PR TITLE
Add optional className prop to IconProps

### DIFF
--- a/generate-data.js
+++ b/generate-data.js
@@ -142,7 +142,7 @@ const createComponentIndex = (files) =>
 
 const createComponentProps = () =>
     new Promise((resolve) => {
-        const indexFileData = `type IconProps = {\n\tsize?:number|string;\n\tcolor?:string;\n\ttitle?:string;\n};\n\nexport default IconProps;`;
+        const indexFileData = `type IconProps = {\n\tsize?:number|string;\n\tcolor?:string;\n\ttitle?:string;\n\tclassName?:string;\n};\n\nexport default IconProps;`;
 
         fs.writeFile(path.join(componentPath, 'props.ts'), indexFileData, () => {});
         resolve();


### PR DESCRIPTION
- There are some icons which uses `className` props for custom styling !
- more details in this pr: https://github.com/mattermost/mattermost/pull/25230
- cc:  @M-ZubairAhmed
