### PR TITLE
Host icon and version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mattermost/compass-icons",
-    "version": "0.1.43",
+    "version": "0.1.44",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@mattermost/compass-icons",
-            "version": "0.1.43",
+            "version": "0.1.44",
             "license": "MIT",
             "devDependencies": {
                 "@types/react": "17.0.39",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mattermost/compass-icons",
-    "version": "0.1.43",
+    "version": "0.1.44",
     "private": true,
     "description": "",
     "main": "build/css/compass-icons.css",

--- a/svgs/monitor-account_F1A5B.svg
+++ b/svgs/monitor-account_F1A5B.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24"> 
+    <path d="M21 2C22.05 2 22.92 2.81 23 3.85L23 4V16C23 17.05 22.18 17.92 21.15 18L21 18H14V20H16V22H8V20H10V18H3C1.95 18 1.08 17.18 1 16.15L1 16V4C1 2.94 1.81 2.08 2.85 2L3 2H21M21 4H3V16H21V4M12 11C14.21 11 16 11.9 16 13V14H8V13C8 11.9 9.79 11 12 11M12 6C13.11 6 14 6.9 14 8S13.11 10 12 10 10 9.11 10 8 10.9 6 12 6Z" />
+</svg>


### PR DESCRIPTION
Adds the `monitor-account` icon to be used for host controls and bumps the version number to 0.1.44 for the next release
